### PR TITLE
Unique constraints refactor for Payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@
 - Spock
 - Refactor
 - Backoffice pagination
+- Refactor PaymentService tests, improve interaction with the Repository

--- a/src/main/java/com/superfintech/superpayment/entity/Payment.java
+++ b/src/main/java/com/superfintech/superpayment/entity/Payment.java
@@ -13,10 +13,8 @@ import java.math.BigDecimal;
 @Builder
 @Entity
 @EqualsAndHashCode
-@Table(uniqueConstraints = {
-        @UniqueConstraint(columnNames = "voucher"),
-        @UniqueConstraint(columnNames = {"voucher", "code"})
-})
+@Table(indexes = {@Index(name = "idx_voucher", columnList = "voucher")},
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"voucher", "code", "companyId"})})
 public class Payment {
 
     @Id

--- a/src/main/java/com/superfintech/superpayment/entity/Payment.java
+++ b/src/main/java/com/superfintech/superpayment/entity/Payment.java
@@ -13,6 +13,10 @@ import java.math.BigDecimal;
 @Builder
 @Entity
 @EqualsAndHashCode
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = "voucher"),
+        @UniqueConstraint(columnNames = {"voucher", "code"})
+})
 public class Payment {
 
     @Id

--- a/src/test/java/com/superfintech/superpayment/service/PaymentServiceTest.java
+++ b/src/test/java/com/superfintech/superpayment/service/PaymentServiceTest.java
@@ -94,8 +94,8 @@ public class PaymentServiceTest {
     @Test
     public void testGetAllPayments() {
         // Mocking
-        Payment payment1 = mock(Payment.class);
-        Payment payment2 = mock(Payment.class);
+        Payment payment1 = new Payment();
+        Payment payment2 = new Payment();
         when(paymentRepository.findAll()).thenReturn(List.of(payment1, payment2));
 
         // Execution

--- a/src/test/java/com/superfintech/superpayment/service/PaymentServiceTest.java
+++ b/src/test/java/com/superfintech/superpayment/service/PaymentServiceTest.java
@@ -2,19 +2,21 @@ package com.superfintech.superpayment.service;
 
 import com.superfintech.superpayment.entity.Payment;
 import com.superfintech.superpayment.repository.PaymentRepository;
+import com.superfintech.superpayment.service.interfaces.TransactionVerifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.math.BigDecimal;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 public class PaymentServiceTest {
@@ -23,7 +25,7 @@ public class PaymentServiceTest {
     private PaymentRepository paymentRepository;
 
     @Mock
-    private VoucherTransactionVerifier transactionVerifier;
+    private TransactionVerifier transactionVerifier;
 
     @InjectMocks
     private PaymentService paymentService;
@@ -35,35 +37,73 @@ public class PaymentServiceTest {
 
     @Test
     public void testProcessPaymentWhenTransactionIsVerified() {
-        // Given
+        // Setup
         String companyId = "company123";
         String code = "code123";
         String voucher = "voucher123";
         BigDecimal orderAmount = BigDecimal.valueOf(100);
 
+        // Mocking
         when(transactionVerifier.verifyTransaction(companyId, code, voucher)).thenReturn(true);
 
-        // When
-        paymentService.processPayment(companyId, code, voucher, orderAmount);
+        // Execution
+        boolean result = paymentService.processPayment(companyId, code, voucher, orderAmount);
 
-        // Then
+        // Verification
+        assertTrue(result);
         verify(paymentRepository, times(2)).save(any(Payment.class));
     }
 
     @Test
     public void testProcessPaymentWhenTransactionIsNotVerified() {
-        // Given
+        // Setup
         String companyId = "company123";
         String code = "code123";
         String voucher = "voucher123";
         BigDecimal orderAmount = BigDecimal.valueOf(100);
 
+        // Mocking
         when(transactionVerifier.verifyTransaction(companyId, code, voucher)).thenReturn(false);
 
-        // When
-        paymentService.processPayment(companyId, code, voucher, orderAmount);
+        // Execution
+        boolean result = paymentService.processPayment(companyId, code, voucher, orderAmount);
 
-        // Then
+        // Verification
+        assertFalse(result);
         verify(paymentRepository, times(2)).save(any(Payment.class));
+    }
+
+    @Test
+    public void testProcessPaymentWhenSaveFails() {
+        // Setup
+        String companyId = "failCompany";
+        String code = "failCode";
+        String voucher = "failVoucher";
+        BigDecimal orderAmount = BigDecimal.valueOf(50);
+
+        // Mocking
+        doThrow(DataIntegrityViolationException.class).when(paymentRepository).save(any(Payment.class));
+
+        // Execution
+        boolean result = paymentService.processPayment(companyId, code, voucher, orderAmount);
+
+        // Verification
+        assertFalse(result);
+    }
+
+    @Test
+    public void testGetAllPayments() {
+        // Mocking
+        Payment payment1 = mock(Payment.class);
+        Payment payment2 = mock(Payment.class);
+        when(paymentRepository.findAll()).thenReturn(List.of(payment1, payment2));
+
+        // Execution
+        List<Payment> payments = paymentService.getAllPayments();
+
+        // Verification
+        assertNotNull(payments);
+        assertEquals(2, payments.size());
+        verify(paymentRepository, times(1)).findAll();
     }
 }


### PR DESCRIPTION
This requieres a PR, for sharing context.

Refactoring the Payments class to avoid concurrency one level up than optimistic locking with @Version.

Why?
Version wasn't enough as there was just an id by transaction being the only constraint besides the same object being managed a memory level. Here the constraint is taking into account the business logic.

I can do more getting rid of the id, but this is good enough for now for ensuring consistency and handling better concurrence by tenant (company)

Things to explore further:
The UUID management.