### PR TITLE
Storing created_at and updated_at timestamps for payments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
+	testImplementation("com.h2database:h2")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/superfintech/superpayment/config/persistence/JpaAuditingConfiguration.java
+++ b/src/main/java/com/superfintech/superpayment/config/persistence/JpaAuditingConfiguration.java
@@ -1,0 +1,9 @@
+package com.superfintech.superpayment.config.persistence;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfiguration {
+}

--- a/src/main/java/com/superfintech/superpayment/config/persistence/JpaAuditorAware.java
+++ b/src/main/java/com/superfintech/superpayment/config/persistence/JpaAuditorAware.java
@@ -1,0 +1,16 @@
+package com.superfintech.superpayment.config.persistence;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+public class JpaAuditorAware implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        return Optional.of("system");
+    }
+}
+

--- a/src/main/java/com/superfintech/superpayment/entity/Payment.java
+++ b/src/main/java/com/superfintech/superpayment/entity/Payment.java
@@ -1,11 +1,27 @@
 package com.superfintech.superpayment.entity;
 
 import com.superfintech.superpayment.entity.status.EnumPaymentStatus;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -13,6 +29,7 @@ import java.math.BigDecimal;
 @Builder
 @Entity
 @EqualsAndHashCode
+@EntityListeners(AuditingEntityListener.class)
 @Table(indexes = {@Index(name = "idx_voucher", columnList = "voucher")},
         uniqueConstraints = {@UniqueConstraint(columnNames = {"voucher", "code", "companyId"})})
 public class Payment {
@@ -36,5 +53,11 @@ public class Payment {
     private int version;
 
     private boolean deleted;
+
+    @CreatedDate
+    private LocalDateTime insertTimestamp;
+
+    @LastModifiedDate
+    private LocalDateTime lastUpdateTimestamp;
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 ##Spring
 spring.application.name=superpayment
 logging.level.org.springframework.security=ERROR
+spring.jpa.properties.hibernate.jdbc.time_zone = UTC
 
 ##Security
 app.user.username=${APP_USER_USERNAME:user}

--- a/src/main/resources/templates/payments.html
+++ b/src/main/resources/templates/payments.html
@@ -86,6 +86,8 @@
             <th>Voucher</th>
             <th>Order Amount</th>
             <th>Status</th>
+            <th>Created at</th>
+            <th>Updated at</th>
         </tr>
         </thead>
         <tbody>
@@ -96,6 +98,8 @@
             <td th:text="${payment.voucher}"></td>
             <td th:text="${payment.orderAmount}"></td>
             <td th:text="${payment.status}"></td>
+            <td th:text="${payment.insertTimestamp}"></td>
+            <td th:text="${payment.lastUpdateTimestamp}"></td>
         </tr>
         </tbody>
     </table>

--- a/src/test/java/com/superfintech/superpayment/integration/PaymentAuditingIntegrationTest.java
+++ b/src/test/java/com/superfintech/superpayment/integration/PaymentAuditingIntegrationTest.java
@@ -1,0 +1,44 @@
+package com.superfintech.superpayment.integration;
+
+import com.superfintech.superpayment.config.persistence.JpaAuditingConfiguration;
+import com.superfintech.superpayment.entity.Payment;
+import com.superfintech.superpayment.entity.status.EnumPaymentStatus;
+import com.superfintech.superpayment.repository.PaymentRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+@Import(JpaAuditingConfiguration.class)
+public class PaymentAuditingIntegrationTest {
+
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    @Test
+    public void whenSavePayment_thenAuditingFieldsPopulated() {
+        Payment payment = Payment.builder()
+                .companyId("123")
+                .code("code123")
+                .voucher("voucher123")
+                .orderAmount(BigDecimal.valueOf(100))
+                .status(EnumPaymentStatus.PENDING)
+                .build();
+
+        Payment savedPayment = paymentRepository.save(payment);
+
+        assertNotNull(savedPayment.getInsertTimestamp(), "Insert timestamp should be populated");
+        assertNotNull(savedPayment.getLastUpdateTimestamp(), "Last update timestamp should be populated");
+
+        assertTrue(savedPayment.getInsertTimestamp().isBefore(LocalDateTime.now().plusMinutes(1)), "Insert timestamp should be recent");
+        assertTrue(savedPayment.getLastUpdateTimestamp().isBefore(LocalDateTime.now().plusMinutes(1)), "Last update timestamp should be recent");
+    }
+}
+


### PR DESCRIPTION
Storing created_at and updated_at timestamps for payments using Springboot JPA auditing capabilities.